### PR TITLE
Set Accessory Info At Add

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -61,6 +61,10 @@ Controller.prototype.addAccessory = function(api_accessory) {
 
   var name = api_accessory.name;
   var service_type = api_accessory.service;
+  var manufacturer = api_accessory.manufacturer;
+  var model = api_accessory.model;
+  var serialnumber = api_accessory.serialnumber;
+  var firmwarerevision = api_accessory.firmwarerevision;
   var service_name;
   var ack, message;
   
@@ -112,7 +116,19 @@ Controller.prototype.addAccessory = function(api_accessory) {
   if (ack) {
     var now = new Date().toISOString().slice(0,16);
     var plugin_v = "v" + plugin_version;
-    this.setAccessoryInformation({"name":name,"manufacturer":plugin_name,"model": plugin_v,"serialnumber":now}, false);
+    if (typeof manufacturer === "undefined") {
+      manufacturer = plugin_name;
+    }
+    if (typeof model === "undefined") {
+      model = plugin_v;
+    }
+    if (typeof serialnumber === "undefined") {
+      serialnumber = now;
+    }
+    if (typeof firmwarerevision === "undefined") {
+      firmwarerevision = plugin_version;
+    }
+    this.setAccessoryInformation({"name":name,"manufacturer":manufacturer,"model":model,"serialnumber":serialnumber,"firmwarerevision":firmwarerevision}, false);
   }
   
   return {"topic": "addAccessory", "ack": ack, "message": message};


### PR DESCRIPTION
The Home app in iOS 11.2 doesn't update accessory information after caching it. This push adds ability to set the info at adding to combat that behavior. Defaults are used as necessary.

i.e.
homebridge/to/add:
```
{
	"name": "ESPFan_01",
	"service_name": "Ceiling Fan",
	"service": "Fan",
	"manufacturer": "Ian Corbitt",
	"model": "ESPFan",
	"serialnumber": "1",
	"firmwarerevision": "0.0.1"
}
```
