### PR TITLE
Added a request_id to requests and responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ topic_type `single`: the data is sent to a single device, the accessory name is 
 topic : homebridge/from/set/flex_lamp
 ```
 
+**Note 2:** 
+
+Optional parameter `request_id`: A unique (user defined) value may be added to any request, it will be included in the corresponding response
+```sh
+request_id : 4711
+```
+
+
 #
 # mqtt API
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -114,7 +114,7 @@ Model.prototype.start = function() {
     if (typeof topic === "undefined" || payload.length === 0) {
       message = "topic or payload invalid";
       this.log.debug("on.message %s", message);
-      this.sendAck(false, message);
+      this.sendAck(false, message, 0);
     } else {
     
       //this.log.debug("on.message topic %s payload %s", topic, payload);
@@ -122,10 +122,17 @@ Model.prototype.start = function() {
       try {
         accessory = JSON.parse(payload);
         
+		if (typeof accessory.request_id === "undefined") {
+	  	  this.log("added request_id=0");
+	  	  accessory.request_id = 0;
+		} else {
+	  	  this.log("request_id %s", accessory.request_id);
+		}
+
         if (typeof accessory.subtype !== "undefined") {
           message = "Please replace 'subtype' by 'service_name'";
           this.log.debug("on.message %s", message);
-          this.sendAck(false, message);
+          this.sendAck(false, message, accessory.request_id);
           isValid = false;
         } else {
           isValid = true;
@@ -133,7 +140,7 @@ Model.prototype.start = function() {
       } catch(e) {
         message = "invalid JSON format";
         this.log.debug("on.message %s (%s)", message, e.message);
-        this.sendAck(false, message);
+        this.sendAck(false, message, 0);
         isValid = false;
       }
 
@@ -143,65 +150,65 @@ Model.prototype.start = function() {
           case topic_prefix + "/to/add/accessory":
             this.log.debug("on.message add \n%s", JSON.stringify(accessory, null, 2));
             result = addAccessory(accessory);
-            this.handle(result, accessory.name);
+            this.handle(result, accessory.name, accessory.request_id);
             break;
 
           case topic_prefix + "/to/add/service":
           case topic_prefix + "/to/add/services":
             this.log.debug("on.message add/service \n%s", JSON.stringify(accessory, null, 2));
             result = addService(accessory);
-            this.handle(result, accessory.name);
+            this.handle(result, accessory.name, accessory.request_id);
             break;
 
           case topic_prefix + "/to/set/reachability":
           case topic_prefix + "/to/set/reachable":
             if (typeof accessory.reachable === "boolean") {
               result = updateReachability(accessory);
-              this.handle(result, accessory.name);
+              this.handle(result, accessory.name, accessory.request_id);
             } else {
               message = "accessory '" + accessory.name + "' reachable not boolean.";
               this.log.warn("on.message %s", message);
-              this.sendAck(false, message);
+              this.sendAck(false, message, accessory.request_id);
             }
             break;
             
           case topic_prefix + "/to/set/accessoryinformation":
           case topic_prefix + "/to/set/information":
             result = setAccessoryInformation(accessory);
-            this.handle(result, accessory.name);
+            this.handle(result, accessory.name, accessory.request_id);
             break;
             
           case topic_prefix + "/to/remove":
           case topic_prefix + "/to/remove/accessory":
             result = removeAccessory(accessory.name);
-            this.handle(result, accessory.name);
+            this.handle(result, accessory.name, accessory.request_id);
             break;
             
           case topic_prefix + "/to/remove/service":
             result = removeService(accessory);
-            this.handle(result, accessory.name);
+            this.handle(result, accessory.name, accessory.request_id);
             break;
             
           case topic_prefix + "/to/set":
             result = setValue(accessory);
             if (!result.ack) {
-              this.handle(result, accessory.name);
+              this.handle(result, accessory.name, accessory.request_id);
             }
             break;
 
           case topic_prefix + "/to/get":
             result = getAccessories(accessory);
             if (result.ack) {
-              this.sendAccessories(result.accessories, accessory.name);
+              this.sendAccessories(result.accessories, accessory.name, accessory.request_id);
             } else {
-              this.handle(result, accessory.name);
+              this.handle(result, accessory.name, accessory.request_id);
             }
             break;
 
           default:
             message = "topic '" + topic + "' unknown.";
             this.log.warn("on.message default %s", message);
-            this.sendAck(false, message);
+            this.sendAck(false, message, accessory.request_id);
         }
       }
     }
@@ -255,23 +262,24 @@ Model.prototype.identify = function (name, manufacturer, model, serialnumber, fi
   client.publish(topic, JSON.stringify(msg), this.publish_options);
 }
 
-Model.prototype.sendAccessories = function (accessories, name) {
+Model.prototype.sendAccessories = function (accessories, name, request_id) {
 
   var msg = accessories;
+  msg.request_id = request_id;
   this.log.debug("sendAccessories \n%s", JSON.stringify(msg, null, 2));
   var topic = this.buildTopic('/from/response', name);
   client.publish(topic, JSON.stringify(msg), this.publish_options);
 }
 
-Model.prototype.handle = function (result, name) {
+Model.prototype.handle = function (result, name, request_id) {
 
-  this.sendAck(result.ack, result.message, name);
-  this.log("%s %s, %s", result.topic, result.ack, result.message);
+  this.sendAck(result.ack, result.message, request_id, name);
+  this.log("%s %s, %s [%s]", result.topic, result.ack, result.message, request_id);
 }
 
-Model.prototype.sendAck = function (ack, message, name) {
+Model.prototype.sendAck = function (ack, message, request_id, name) {
 
-  var msg = {"ack": ack, "message": message};
+  var msg = {"ack": ack, "message": message, "request_id": request_id};
   //this.log.debug("sendAck %s", JSON.stringify(msg));
   var topic = this.buildTopic('/from/response', name);
   client.publish(topic, JSON.stringify(msg), this.publish_options);


### PR DESCRIPTION
To allow the identification of homebridge-mqtt responses, a 'request_id' was added as a request parameter and this 'request_id' is returned with the response.
If no 'request_id' is given, a "request_id" : 0 will be responded, so this shouldn't disturb anyone.