### PR TITLE
Properties option for get all accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,110 @@ payload:
 }
 ```
 
+```sh
+topic: homebridge/to/get
+payload: {"name": "*_props"}
+```
+
+homebridge sends all accessory configurations, including properties:
+
+```sh
+topic: homebridge/from/response
+payload:
+{
+  "node_switch": {
+    "services": {
+      "light": "Switch"
+    },
+    "characteristics": {
+      "Light": {
+        "On": true
+      }
+    },
+    "properties": {
+      "Light": {
+        "On": {
+          "format": "bool",
+          "unit": null,
+          "minValue": null,
+          "maxValue": null,
+          "minStep": null,
+          "perms": [
+            "pr",
+            "pw",
+            "ev"
+          ]
+        }
+      }
+    },
+    "office_lamp": {
+      "services": {
+        "office_light": "Lightbulb"
+      },
+      "characteristics": {
+        "office_light": {
+          "On": "blank",
+          "Brightness": 65
+        }
+      },
+      "properties": {
+        "office_light": {
+          "On": {
+            "format": "bool",
+            "unit": null,
+            "minValue": null,
+            "maxValue": null,
+            "minStep": null,
+            "perms": [
+              "pr",
+              "pw",
+              "ev"
+            ]
+          },
+          "Brightness": {
+            "format": "int",
+            "unit": "percentage",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1,
+            "perms": [
+              "pr",
+              "pw",
+              "ev"
+            ]
+          }
+        }
+      }
+    },
+    "living_temp": {
+      "services": {
+        "living_temperature": "TemperatureSensor"
+      },
+      "characteristics": {
+        "living_temperature": {
+          "CurrentTemperature": 19.6
+        }
+      },
+      "properties": {
+        "living_temperature": {
+          "CurrentTemperature": {
+            "format": "float",
+            "unit": "celsius",
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 0.1,
+            "perms": [
+              "pr",
+              "ev"
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### set value (to homebridge)
 
 ```sh

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -311,7 +311,7 @@ Controller.prototype.getAccessories = function(api_accessory) {
 
   var name;
   var accessories = {};
-  var service, characteristics;
+  var service, characteristics, properties;
   var ack, message;
   
   if (typeof api_accessory.name !== "undefined") {
@@ -320,7 +320,7 @@ Controller.prototype.getAccessories = function(api_accessory) {
     name = "*";
   }
   
-  if (name !== "*" && typeof(this.accessories[name]) === "undefined") {
+  if (name !== "*" && name !== "all" && name !== "*_props" && name !== "all_props" && typeof(this.accessories[name] === "undefined")) {
     ack = false; message = "name '" + name + "' undefined.";
     
   } else {
@@ -332,6 +332,16 @@ Controller.prototype.getAccessories = function(api_accessory) {
           service = this.accessories[k].service_types;
           characteristics =  this.accessories[k].i_value;
           accessories[k] = {"services": service, "characteristics": characteristics};
+        }
+      break;
+      case "*_props":
+      case "all_props":
+        for (var k in this.accessories) {
+          //this.log.debug("Controller.getAccessories %s", JSON.stringify(this.accessories[k], null, 2));
+          service = this.accessories[k].service_types;
+          characteristics =  this.accessories[k].i_value;
+          properties = this.accessories[k].i_props;
+          accessories[k] = {"services": service, "characteristics": characteristics, "properties": properties};
         }
       break;
       


### PR DESCRIPTION
Added the ability to also capture characteristic properties of each accessory with the homebridge/to/get topic. This is achieved by using an additional {"name": "*_props"} payload to avoid backwards compatibility issues.