### PR TITLE
Ease the access to cached values

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On", 
 
 ```sh
 topic: homebridge/from/get
-payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On"}
+payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On", "cachedValue": true}
 ```
 
 Homebridge-mqtt will return the cached value to HomeKit. Optionally you can publish the actual value using
@@ -263,6 +263,20 @@ Homebridge-mqtt will return the cached value to HomeKit. Optionally you can publ
 
 ```sh
 topic: homebridge/from/set
+payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On", "value": true}
+```
+
+### get (cached) value (to homebridge)
+
+```sh
+topic: homebridge/to/get/characteristic
+payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On"}
+```
+
+response:
+
+```sh
+topic: homebridge/from/response
 payload: {"name": "flex_lamp", "service_name": "light", "characteristic": "On", "value": true}
 ```
 

--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -238,15 +238,16 @@ Accessory.prototype.get = function(callback, context, displayName, iid) {
     }
     var service_name = this.service_names[iid];
     
-    this.log.debug("Accessory.get [iid %s] '%s' '%s' '%s'", iid, this.name, service_name, c);
-    get(this.name, service_name, c, callback);
-    
     var value;
     if (typeof(this.i_value[service_name][c]) !== "undefined" && this.i_value[service_name][c] !== "blank") {
       value = this.i_value[service_name][c];
     } else {
       value = null;
     }
+    
+    this.log.debug("Accessory.get [iid %s] '%s' '%s' '%s' '%s'", iid, this.name, service_name, c, value);
+    get(this.name, service_name, c, value, callback);
+
     //this.log.debug("Accessory.get %s %s %s", this.name, c, value);
     callback(null, value);
   } else {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -40,6 +40,7 @@ function Controller(params) {
     "removeService": this.removeService.bind(this),
     "setValue": this.setValue.bind(this),
     "getAccessories": this.getAccessories.bind(this),
+    "getCharacteristic": this.getCharacteristic.bind(this),
     "updateReachability": this.updateReachability.bind(this),
     "setAccessoryInformation": this.setAccessoryInformation.bind(this)
   };
@@ -78,6 +79,9 @@ Controller.prototype.addAccessory = function(api_accessory) {
   if (typeof name === "undefined") {
     ack = false; message = "name undefined.";
     
+  } else if (name === "") {
+    ack = false; message = "invalid/no name.";
+
   } else if (typeof service_type === "undefined") {
     ack = false; message = "service undefined."; 
       
@@ -346,6 +350,46 @@ Controller.prototype.getAccessories = function(api_accessory) {
   return {"topic": "getAccessories", "ack": ack, "message": message, "accessories": accessories};
 }
 
+Controller.prototype.getCharacteristic = function(api_accessory) {
+
+  var name = api_accessory.name;
+  var service_name = api_accessory.service_name;
+  var characteristic = api_accessory.characteristic;
+  var ack, message;
+  var response = {};
+
+  if (typeof name === "undefined") {
+    ack = false; message = "name undefined.";
+
+  } else if (typeof this.accessories[name] === "undefined") {
+    ack = false; message = "accessory '" + name + "' not found.";
+
+  } else if (typeof service_name === "undefined") {
+    ack = false; message = "service_name undefined.";
+
+  } else if (this.accessories[name].service_namesList.indexOf(service_name) < 0) {
+    ack = false; message = "accessory '" + name + "', service_name '" + service_name + "' undefined.";
+  
+  } else if (typeof this.hap_accessories[name].getServiceByUUIDAndSubType(service_name, service_name) === "undefined") {   
+    ack = false; message = "accessory '" + name + "', service_name '" + service_name + "' not found.";
+  
+  } else if (typeof(Characteristic[characteristic]) !== "function") {
+    ack = false; message = "characteristic '" + characteristic + "' undefined.";
+
+  } else if (typeof(this.accessories[name].services[service_name].getCharacteristic(Characteristic[characteristic])) === "undefined") {
+    ack = false; message = "name '" + name + "' service_name '" + service_name + "' characteristic '" + characteristic + "' do not match.";
+
+  } else {
+    ack = true; message = "characteristic found.";
+
+    response.name = name;
+    response.service_name = service_name;
+    response.characteristic = characteristic;
+    response.value = this.accessories[name].services[service_name].getCharacteristic(Characteristic[characteristic]).value;
+  }
+  return {"topic": "getCharacteristic", "ack": ack, "message": message, "characteristic": response};
+}
+
 //
 // Model functions
 //
@@ -361,9 +405,9 @@ Controller.prototype.start = function () {
   this.Model.start();
 }
 
-Controller.prototype.get = function (name, service_name, c, callback) {
+Controller.prototype.get = function (name, service_name, c, value, callback) {
 
-  this.Model.get(name, service_name, c, callback);
+  this.Model.get(name, service_name, c, value, callback);
 }
 
 Controller.prototype.set = function (name, service_name, c, value, callback) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -5,7 +5,7 @@ var Utils = require('./utils.js').Utils;
 var fs = require('fs');
 
 var plugin_name, topic_type, topic_prefix, Characteristic;
-var addAccessory, addService, removeAccessory, removeService, setValue, getAccessories, updateReachability, setAccessoryInformation;
+var addAccessory, addService, removeAccessory, removeService, setValue, getAccessories, getCharacteristic, updateReachability, setAccessoryInformation;
 var set_timeout, client;
 
 module.exports = {
@@ -25,6 +25,7 @@ function Model(params) {
   removeService = params.removeService;
   setValue = params.setValue;
   getAccessories = params.getAccessories;
+  getCharacteristic = params.getCharacteristic;
   updateReachability = params.updateReachability;
   setAccessoryInformation = params.setAccessoryInformation;
 }
@@ -123,10 +124,10 @@ Model.prototype.start = function() {
         accessory = JSON.parse(payload);
         
 		if (typeof accessory.request_id === "undefined") {
-	  	  this.log("added request_id=0");
+	  	  //this.log("added request_id=0");
 	  	  accessory.request_id = 0;
 		} else {
-	  	  this.log("request_id %s", accessory.request_id);
+	  	  //this.log("request_id %s", accessory.request_id);
 		}
 
         if (typeof accessory.subtype !== "undefined") {
@@ -205,6 +206,16 @@ Model.prototype.start = function() {
             }
             break;
 
+          case topic_prefix + "/to/get/characteristic":
+            this.log("/to/get/characteristic: %s", JSON.stringify(accessory));
+            result = getCharacteristic(accessory);
+            if (result.ack) {
+              this.sendCharacteristic(result.characteristic, accessory.name, accessory.request_id);
+            } else {
+              this.handle(result, accessory.name, accessory.request_id);
+            }
+            break;
+
           default:
             message = "topic '" + topic + "' unknown.";
             this.log.warn("on.message default %s", message);
@@ -236,10 +247,10 @@ Model.prototype.start = function() {
  
 }
 
-Model.prototype.get = function(name, service_name, c, callback) {
+Model.prototype.get = function(name, service_name, c, value, callback) {
 
-  //this.log.debug("get '%s' '%s' '%s'", name, service_name, c);
-  var msg = {"name": name, "service_name": service_name, "characteristic": c};
+  //this.log.debug("get '%s' '%s' '%s' '%s'", name, service_name, c, value);
+  var msg = {"name": name, "service_name": service_name, "characteristic": c, "cachedValue": value};
   var topic = this.buildTopic('/from/get', name);
   client.publish(topic, JSON.stringify(msg), this.publish_options);
   // callback(null, null);  // not used
@@ -267,6 +278,15 @@ Model.prototype.sendAccessories = function (accessories, name, request_id) {
   var msg = accessories;
   msg.request_id = request_id;
   this.log.debug("sendAccessories \n%s", JSON.stringify(msg, null, 2));
+  var topic = this.buildTopic('/from/response', name);
+  client.publish(topic, JSON.stringify(msg), this.publish_options);
+}
+
+Model.prototype.sendCharacteristic = function (characteristic, name, request_id) {
+
+  var msg = characteristic;
+  msg.request_id = request_id;
+  this.log.debug("sendCharacteristic \n%s", JSON.stringify(msg, null, 2));
   var topic = this.buildTopic('/from/response', name);
   client.publish(topic, JSON.stringify(msg), this.publish_options);
 }


### PR DESCRIPTION
To reduce network traffic the cached value was added to 'homebridge/from/get' messages and a new 'homebridge/to/get/characteristic' message was added. As a result, the user can check now, if a 'homebridge/to/set' message is needed when receiving a 'homebridge/from/get' message.