### PR TITLE
make client id configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Go to Homebridge Config UI X, select `Plugins > Homebridge Mqtt` and click `SETT
     "cert": "/path/to/certificate.pem",
     "key": "path/to/key.pem",
     "ca": "/path/to/ca_certificate.pem",
+    "client_id": "some-string",
     "topic_type": "multiple",
     "topic_prefix": "homebridge"
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -63,6 +63,12 @@
         "required": false,
         "description": "Path to the ca_certificate (optional)."
       },
+      "client_id": {
+        "title": "client_id",
+        "type": "string",
+        "required": false,
+        "description": "Mqtt client id (optional)."
+      },
       "topic_type": {
         "title": "topic_type",
         "type": "string",

--- a/lib/model.js
+++ b/lib/model.js
@@ -65,7 +65,7 @@ Model.prototype.start = function() {
   //options.keepalive = 60;
   //options.clean = true;
   
-  options.clientId = 'homebridge-mqtt_' + Math.random().toString(16).substr(2, 8);
+  options.clientId = this.config.client_id || 'homebridge-mqtt_' + Math.random().toString(16).substr(2, 8);
   this.log("clientId = %s", options.clientId);
   
   this.log("Connecting..");


### PR DESCRIPTION
Allow the mqtt client id to be configurable.  This is helpful when running multiple instances of homebridge-mqtt.